### PR TITLE
cleanup: refactor ak4619/i2cinit/cal/top to use more SV constructs

### DIFF
--- a/gateware/ak4619/ak4619-cfg.hex
+++ b/gateware/ak4619/ak4619-cfg.hex
@@ -10,7 +10,7 @@ AC // 0x01 Audio I/F Format
 30 // 0x07 ADC1 Rch Digital Volume
 30 // 0x08 ADC2 Lch Digital Volume
 30 // 0x09 ADC2 Rch Digital Volume
-00 // 0x0A ADC Digital Filter Setting
+22 // 0x0A ADC Digital Filter Setting
 55 // 0x0B ADC Analog Input Setting
 00 // 0x0C Reserved
 06 // 0x0D ADC Mute & HPF Control

--- a/gateware/ak4619/ak4619.sv
+++ b/gateware/ak4619/ak4619.sv
@@ -10,7 +10,7 @@
 module ak4619 #(
     parameter int W = 16 // sample width, bits
 )(
-    input  clk,   // Assumed 24MHz
+    input  clk,   // Assumed 12MHz
     output pdn,
     output mclk,
     output bick,
@@ -46,7 +46,7 @@ logic sda_out_i2cinit;
 assign pdn         = 1'b1;
 assign bick        = clk;
 assign mclk        = clk;
-assign lrck        = clkdiv[6];   // 24MHz >> 7 == 187.5KHz
+assign lrck        = clkdiv[6];   // 12MHz >> 7 == 93.75KHz
 assign i2c_scl     = scl_i2cinit     ? 1'bz : 1'b0;
 assign i2c_sda     = sda_out_i2cinit ? 1'bz : 1'b0;
 

--- a/gateware/ak4619/ak4619.sv
+++ b/gateware/ak4619/ak4619.sv
@@ -3,11 +3,11 @@
 // Currently assumes the device is configured in the audio
 // interface mode specified in ak4619-cfg.c.
 //
-// Currently 93.75KHz/16bit samples, but there is no reason
+// Currently 187.5KHz/16bit samples, but there is no reason
 // we can't go higher, just need to experiment.
 
 module ak4619 (
-    input  clk,   // Assumed 12MHz
+    input  clk,   // Assumed 24MHz
     output pdn,
     output mclk,
     output bick,
@@ -38,7 +38,7 @@ assign i2c_sda = sda_out_i2cinit ? 1'bz : 1'b0;
 
 assign bick = clk;
 assign mclk = clk;
-assign lrck = clkdiv[6]; // 12MHz >> 7 == 93.75KHz
+assign lrck = clkdiv[6]; // 24MHz >> 7 == 187.5KHz
 assign sample_clk = lrck;
 
 

--- a/gateware/ak4619/ak4619.sv
+++ b/gateware/ak4619/ak4619.sv
@@ -1,12 +1,15 @@
 // Driver for AK4619 ADC/DAC
 //
 // Currently assumes the device is configured in the audio
-// interface mode specified in ak4619-cfg.c.
+// interface mode specified in ak4619-cfg.hex.
 //
-// Currently 187.5KHz/16bit samples, but there is no reason
-// we can't go higher, just need to experiment.
+// Currently 187.5KHz/16bit samples.
 
-module ak4619 (
+`default_nettype none
+
+module ak4619 #(
+    parameter int W = 16 // sample width, bits
+)(
     input  clk,   // Assumed 24MHz
     output pdn,
     output mclk,
@@ -15,74 +18,77 @@ module ak4619 (
     output reg sdin1,
     input  sdout1,
     output i2c_scl,
-    inout  i2c_sda,
+    inout i2c_sda,
 
     output sample_clk,
-    output signed [15:0] sample_out0,
-    output signed [15:0] sample_out1,
-    output signed [15:0] sample_out2,
-    output signed [15:0] sample_out3,
-    input signed [15:0] sample_in0,
-    input signed [15:0] sample_in1,
-    input signed [15:0] sample_in2,
-    input signed [15:0] sample_in3
+    output reg signed [W-1:0] sample_out0,
+    output reg signed [W-1:0] sample_out1,
+    output reg signed [W-1:0] sample_out2,
+    output reg signed [W-1:0] sample_out3,
+    input  signed [W-1:0] sample_in0,
+    input  signed [W-1:0] sample_in1,
+    input  signed [W-1:0] sample_in2,
+    input  signed [W-1:0] sample_in3
 );
 
-assign pdn = 1'b1;
+localparam int N_CHANNELS = 4;
 
-wire scl_i2cinit;
-wire sda_out_i2cinit;
-assign i2c_scl = scl_i2cinit ? 1'bz : 1'b0;
-assign i2c_sda = sda_out_i2cinit ? 1'bz : 1'b0;
+logic signed [W-1:0] dac_words [N_CHANNELS];
+logic signed [W-1:0] adc_words [N_CHANNELS];
 
+logic sdout1_latched    = 1'b0;
+logic [7:0] clkdiv      = 8'd0;
+logic [1:0] channel;
+logic [4:0] bit_counter;
+logic scl_i2cinit;
+logic sda_out_i2cinit;
 
-assign bick = clk;
-assign mclk = clk;
-assign lrck = clkdiv[6]; // 24MHz >> 7 == 187.5KHz
-assign sample_clk = lrck;
+assign pdn         = 1'b1;
+assign bick        = clk;
+assign mclk        = clk;
+assign lrck        = clkdiv[6];   // 24MHz >> 7 == 187.5KHz
+assign i2c_scl     = scl_i2cinit     ? 1'bz : 1'b0;
+assign i2c_sda     = sda_out_i2cinit ? 1'bz : 1'b0;
 
+assign channel     = clkdiv[6:5]; // 0 == L (Ch0), 1 == R (Ch1)
+assign bit_counter = clkdiv[4:0];
+assign sample_clk  = lrck;
 
-reg signed [15:0] dac_words [0:3];
-reg signed [15:0] adc_words [0:3];
-assign sample_out0 = adc_words[0];
-assign sample_out1 = adc_words[1];
-assign sample_out2 = adc_words[2];
-assign sample_out3 = adc_words[3];
-
-always @(negedge lrck) begin
+always_ff @(negedge sample_clk) begin
     dac_words[0] <= sample_in0;
     dac_words[1] <= sample_in1;
     dac_words[2] <= sample_in2;
     dac_words[3] <= sample_in3;
+    sample_out0  <= adc_words[0];
+    sample_out1  <= adc_words[1];
+    sample_out2  <= adc_words[2];
+    sample_out3  <= adc_words[3];
 end
 
-reg [7:0] clkdiv = 8'd0;
-wire [1:0] channel = clkdiv[6:5]; // 0 == L (Ch0), 1 == R (Ch1)
-wire [4:0] bit_counter = clkdiv[4:0];
-always @(negedge bick) begin
-    clkdiv <= clkdiv + 1;
+always_ff @(negedge clk) begin
     // Clock out 16 bits
-    if (bit_counter <= 5'hF) begin
-        sdin1 <= dac_words[channel][5'hF - bit_counter];
+    if (bit_counter <= (W-1)) begin
+        sdin1 <= dac_words[channel][(W-1) - bit_counter];
     end else begin
         sdin1 <= 0;
     end
     // Clock in 16 bits
-    if (bit_counter == 5'h0) begin
-        adc_words[channel] <= 16'h0;
+    if (bit_counter == 0) begin
+        adc_words[channel] <= 0;
     end
-    if (bit_counter <= 5'h10) begin
-        adc_words[channel][5'h10 - bit_counter] <= sdout1_latched;
+    if (bit_counter <= W) begin
+        adc_words[channel][W - bit_counter] <= sdout1_latched;
     end
+
+    clkdiv <= clkdiv + 1;
 end
 
-reg sdout1_latched = 1'b0;
-always @(posedge bick) begin
+always_ff @(posedge clk) begin
     sdout1_latched <= sdout1;
 end
 
 i2cinit i2cinit_instance (
-    .clk (lrck),
+    .clk (sample_clk),
     .scl (scl_i2cinit),
     .sda_out (sda_out_i2cinit)
 );

--- a/gateware/cal/cal.py
+++ b/gateware/cal/cal.py
@@ -60,7 +60,7 @@ def twos_comp(val, bits):
         val = val - (1 << bits)        # compute negative value
     return val                         # return positive value as is
 
-ser = serial.Serial(SERIAL_PORT, 115200)
+ser = serial.Serial(SERIAL_PORT, 1000000)
 
 ch_avg = np.zeros(4)
 p5v_avg = np.zeros(4)

--- a/gateware/cal/cal.py
+++ b/gateware/cal/cal.py
@@ -60,7 +60,7 @@ def twos_comp(val, bits):
         val = val - (1 << bits)        # compute negative value
     return val                         # return positive value as is
 
-ser = serial.Serial(SERIAL_PORT, 1000000)
+ser = serial.Serial(SERIAL_PORT, 115200)
 
 ch_avg = np.zeros(4)
 p5v_avg = np.zeros(4)

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -17,7 +17,7 @@ module cal #(
     parameter int W = 16, // sample width
     parameter CAL_MEM_FILE = "cal_mem.hex"
 )(
-    input clk, // 24Mhz
+    input clk, // 12Mhz
     input sample_clk,
     input signed [W-1:0] in0,
     input signed [W-1:0] in1,

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -11,47 +11,54 @@
 // documented in `cal.py`. This module only uses a single multiplier for
 // all channels such that there are plenty left over for user logic.
 
-module cal (
+`default_nettype none
+
+module cal #(
+    parameter integer W = 16, // sample width
+    parameter CAL_MEM_FILE = "cal_mem.hex"
+)(
     input clk, // 24Mhz
     input sample_clk,
-    input signed [15:0] in0,
-    input signed [15:0] in1,
-    input signed [15:0] in2,
-    input signed [15:0] in3,
-    input signed [15:0] in4,
-    input signed [15:0] in5,
-    input signed [15:0] in6,
-    input signed [15:0] in7,
-    output logic signed [15:0] out0,
-    output logic signed [15:0] out1,
-    output logic signed [15:0] out2,
-    output logic signed [15:0] out3,
-    output logic signed [15:0] out4,
-    output logic signed [15:0] out5,
-    output logic signed [15:0] out6,
-    output logic signed [15:0] out7
+    input signed [W-1:0] in0,
+    input signed [W-1:0] in1,
+    input signed [W-1:0] in2,
+    input signed [W-1:0] in3,
+    input signed [W-1:0] in4,
+    input signed [W-1:0] in5,
+    input signed [W-1:0] in6,
+    input signed [W-1:0] in7,
+    output logic signed [W-1:0] out0,
+    output logic signed [W-1:0] out1,
+    output logic signed [W-1:0] out2,
+    output logic signed [W-1:0] out3,
+    output logic signed [W-1:0] out4,
+    output logic signed [W-1:0] out5,
+    output logic signed [W-1:0] out6,
+    output logic signed [W-1:0] out7
 );
 
-localparam CAL_ST_ZERO      = 3'd0,
-           CAL_ST_MULTIPLY  = 3'd1,
-           CAL_ST_CLAMPL    = 3'd2,
-           CAL_ST_OUT       = 3'd3,
-           CAL_ST_HALT      = 3'd4;
+localparam int N_CHANNELS = 8;
+
+localparam int CAL_ST_ZERO      = 3'd0,
+               CAL_ST_MULTIPLY  = 3'd1,
+               CAL_ST_CLAMPL    = 3'd2,
+               CAL_ST_OUT       = 3'd3,
+               CAL_ST_HALT      = 3'd4;
 
 // Only need to clamp negative values as with current hardware it
 // is impossible to overflow in the positive direction during cal.
-localparam CLAMPL = -32'sd32000;
+localparam int signed CLAMPL = -32'sd32000;
 
-logic signed [15:0] cal_mem [0:15];
-logic signed [15:0] in      [0:7];
-logic signed [31:0] out     [0:7];
-logic        [2:0]  ch = 3'd0;
-logic        [2:0]  state = CAL_ST_ZERO;
+logic signed [W-1:0]     cal_mem [2*N_CHANNELS];
+logic signed [W-1:0]     in      [N_CHANNELS];
+logic signed [(2*W)-1:0] out     [N_CHANNELS];
+logic        [2:0]       ch      = 0;
+logic        [2:0]       state   = CAL_ST_ZERO;
 logic               l_sample_clk = 1'd0;
 
 // Calibration memory for 8 channels stored as
 // 2 bytes shift, 2 bytes multiply * 8 channels.
-initial $readmemh("cal_mem.hex", cal_mem);
+initial $readmemh(CAL_MEM_FILE, cal_mem);
 
 always_ff @(posedge clk) begin
 
@@ -74,11 +81,11 @@ always_ff @(posedge clk) begin
     case (state)
         CAL_ST_ZERO: begin
             out[ch] <= (in[ch] - cal_mem[{ch, 1'b0}]);
-            if (ch == 7) state <= CAL_ST_MULTIPLY;
+            if (ch == N_CHANNELS-1) state <= CAL_ST_MULTIPLY;
         end
         CAL_ST_MULTIPLY: begin
             out[ch] <= (out[ch] * cal_mem[{ch, 1'b1}]) >>> 10;
-            if (ch == 7) state <= CAL_ST_OUT;
+            if (ch == N_CHANNELS-1) state <= CAL_ST_OUT;
         end
         CAL_ST_OUT: begin
             // TODO(sebholzapfel): add CLAMPL to pipeline.
@@ -91,6 +98,9 @@ always_ff @(posedge clk) begin
             out6  <= out[6] < CLAMPL ? CLAMPL : out[6];
             out7  <= out[7] < CLAMPL ? CLAMPL : out[7];
             state <= CAL_ST_HALT;
+        end
+        default: begin
+            // Halt and do nothing.
         end
     endcase
 

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -12,7 +12,7 @@
 // all channels such that there are plenty left over for user logic.
 
 module cal (
-    input clk, // 12Mhz
+    input clk, // 24Mhz
     input sample_clk,
     input signed [15:0] in0,
     input signed [15:0] in1,
@@ -32,44 +32,69 @@ module cal (
     output logic signed [15:0] out7
 );
 
+localparam CAL_ST_ZERO     = 2'd0,
+           CAL_ST_MULTIPLY = 2'd1,
+           CAL_ST_HALT     = 2'd2;
+
 logic signed [15:0] cal_mem [0:15];
 logic signed [15:0] in      [0:7];
-logic signed [15:0] out     [0:7];
-logic signed [31:0] calibrated;
-// Index of channel we are calibrating
-logic        [2:0]  ch = 3'd0;
+logic signed [31:0] out     [0:7];
+logic        [2:0]  ch           = 3'd0;
+logic        [1:0]  state        = CAL_ST_ZERO;
+logic               l_sample_clk = 1'd0;
+
 
 // Calibration memory for 8 channels stored as
 // 2 bytes shift, 2 bytes multiply * 8 channels.
 initial $readmemh("cal_mem.hex", cal_mem);
 
-always @(posedge sample_clk) begin
-    in[0] <= in0;
-    in[1] <= in1;
-    in[2] <= in2;
-    in[3] <= in3;
-    in[4] <= in4;
-    in[5] <= in5;
-    in[6] <= in6;
-    in[7] <= in7;
-    out0  <= out[0];
-    out1  <= out[1];
-    out2  <= out[2];
-    out3  <= out[3];
-    out4  <= out[4];
-    out5  <= out[5];
-    out6  <= out[6];
-    out7  <= out[7];
-end
-
-always_comb begin
-    calibrated = ((in[ch] - cal_mem[{ch, 1'b0}])
-                  * cal_mem[{ch, 1'b1}]) >>> 10;
-end
-
 always_ff @(posedge clk) begin
-    out[ch] <= calibrated;
-    ch <= ch + 1;
+
+    // On rising sample_clk.
+    if (sample_clk && (l_sample_clk != sample_clk)) begin
+        state <= CAL_ST_ZERO;
+        ch <= 0;
+        in[0] <= in0;
+        in[1] <= in1;
+        in[2] <= in2;
+        in[3] <= in3;
+        in[4] <= in4;
+        in[5] <= in5;
+        in[6] <= in6;
+        in[7] <= in7;
+
+        out0  <= out[0];
+        out1  <= out[1];
+        out2  <= out[2];
+        out3  <= out[3];
+        out4  <= out[4];
+        out5  <= out[5];
+        out6  <= out[6];
+        out7  <= out[7];
+    end else begin
+        ch <= ch + 1;
+    end
+
+    case (state)
+        CAL_ST_ZERO: begin
+            out[ch] <= (in[ch] - cal_mem[{ch, 1'b0}]);
+            if (ch == 7) state <= CAL_ST_MULTIPLY;
+        end
+        CAL_ST_MULTIPLY: begin
+            out[ch] <= (out[ch] * cal_mem[{ch, 1'b1}]) >>> 10;
+            if (ch == 7) state <= CAL_ST_HALT;
+        end
+    endcase
+
+    l_sample_clk <= sample_clk;
 end
+
+`ifdef COCOTB_SIM
+initial begin
+  $dumpfile ("cal.vcd");
+  $dumpvars;
+  #1;
+end
+`endif
 
 endmodule

--- a/gateware/cal/cal.sv
+++ b/gateware/cal/cal.sv
@@ -22,65 +22,54 @@ module cal (
     input signed [15:0] in5,
     input signed [15:0] in6,
     input signed [15:0] in7,
-    output signed [15:0] out0,
-    output signed [15:0] out1,
-    output signed [15:0] out2,
-    output signed [15:0] out3,
-    output signed [15:0] out4,
-    output signed [15:0] out5,
-    output signed [15:0] out6,
-    output signed [15:0] out7
+    output logic signed [15:0] out0,
+    output logic signed [15:0] out1,
+    output logic signed [15:0] out2,
+    output logic signed [15:0] out3,
+    output logic signed [15:0] out4,
+    output logic signed [15:0] out5,
+    output logic signed [15:0] out6,
+    output logic signed [15:0] out7
 );
 
-// Clamp cal_in to +/- 7V (28/4)
-localparam CLAMP_HI = 28000;
-localparam CLAMP_LO = -28000;
+logic signed [15:0] cal_mem [0:15];
+logic signed [15:0] in      [0:7];
+logic signed [15:0] out     [0:7];
+logic signed [31:0] calibrated;
+// Index of channel we are calibrating
+logic        [2:0]  ch = 3'd0;
 
 // Calibration memory for 8 channels stored as
 // 2 bytes shift, 2 bytes multiply * 8 channels.
-reg signed [15:0] cal_mem [0:15];
 initial $readmemh("cal_mem.hex", cal_mem);
 
-reg signed [15:0] adc_in_latched [0:7];
-
 always @(posedge sample_clk) begin
-    adc_in_latched[0] <= in0;
-    adc_in_latched[1] <= in1;
-    adc_in_latched[2] <= in2;
-    adc_in_latched[3] <= in3;
-    adc_in_latched[4] <= in4;
-    adc_in_latched[5] <= in5;
-    adc_in_latched[6] <= in6;
-    adc_in_latched[7] <= in7;
+    in[0] <= in0;
+    in[1] <= in1;
+    in[2] <= in2;
+    in[3] <= in3;
+    in[4] <= in4;
+    in[5] <= in5;
+    in[6] <= in6;
+    in[7] <= in7;
+    out0  <= out[0];
+    out1  <= out[1];
+    out2  <= out[2];
+    out3  <= out[3];
+    out4  <= out[4];
+    out5  <= out[5];
+    out6  <= out[6];
+    out7  <= out[7];
 end
 
-// Source signal of calibration pipeline below so we only need 1 multiply
-// for all 8 channels during 1 sample_clk.
-wire signed [31:0] cal_unclamped = (
-    (adc_in_latched[cur_channel] - cal_mem[{cur_channel, 1'b0}])
-     * cal_mem[{cur_channel, 1'b1}]) >>> 10;
-
-reg [2:0] cur_channel = 3'd0;
-reg signed [15:0] outputs [0:7];
-
-always @(posedge clk) begin
-    if (CLAMP_HI < cal_unclamped && cal_unclamped < 16'h8000)
-        outputs[cur_channel] <= CLAMP_HI;
-    else if (16'h8000 <= cal_unclamped && cal_unclamped < CLAMP_LO)
-        outputs[cur_channel] <= CLAMP_LO;
-    else
-        outputs[cur_channel] <= cal_unclamped;
-    // FIXME: stop wrapping around after all channels updated..
-    cur_channel <= cur_channel + 1;
+always_comb begin
+    calibrated = ((in[ch] - cal_mem[{ch, 1'b0}])
+                  * cal_mem[{ch, 1'b1}]) >>> 10;
 end
 
-assign out0 = outputs[0];
-assign out1 = outputs[1];
-assign out2 = outputs[2];
-assign out3 = outputs[3];
-assign out4 = outputs[4];
-assign out5 = outputs[5];
-assign out6 = outputs[6];
-assign out7 = outputs[7];
+always_ff @(posedge clk) begin
+    out[ch] <= calibrated;
+    ch <= ch + 1;
+end
 
 endmodule

--- a/gateware/sim/ak4619/tb_ak4619.py
+++ b/gateware/sim/ak4619/tb_ak4619.py
@@ -34,7 +34,7 @@ async def test_ak4619_00(dut):
 
     dut.sdout1.value = 0
 
-    await FallingEdge(dut.lrck)
+    await FallingEdge(dut.sample_clk)
     await clock_out_word(dut, TEST_L0)
     await clock_out_word(dut, TEST_R0)
     await clock_out_word(dut, TEST_L1)
@@ -42,6 +42,8 @@ async def test_ak4619_00(dut):
 
     # Note: this edge is also where dac_words <= sample_in (sample.sv)
 
+    await RisingEdge(dut.sample_clk)
+    await FallingEdge(dut.sample_clk)
     print("Data clocked from sdout1 present at sample_outX:")
     print(hex(dut.sample_out0.value))
     print(hex(dut.sample_out1.value))
@@ -58,8 +60,8 @@ async def test_ak4619_00(dut):
     dut.sample_in2.value = Force(TEST_L1)
     dut.sample_in3.value = Force(TEST_R1)
 
-    await FallingEdge(dut.lrck)
-    await FallingEdge(dut.lrck)
+    await FallingEdge(dut.sample_clk)
+    await FallingEdge(dut.sample_clk)
 
     result_l0 = await clock_in_word(dut)
     result_r0 = await clock_in_word(dut)
@@ -82,4 +84,4 @@ async def test_ak4619_00(dut):
     dut.sample_in2.value = Release()
     dut.sample_in3.value = Release()
 
-    await FallingEdge(dut.lrck)
+    await FallingEdge(dut.sample_clk)

--- a/gateware/sim/cal/tb_cal.py
+++ b/gateware/sim/cal/tb_cal.py
@@ -18,10 +18,10 @@ def twos_comp_to_signed(n, numbits=16):
 @cocotb.test()
 async def test_cal_00(dut):
 
-    clock = Clock(dut.sample_clk, 5, units='us')
-    cocotb.start_soon(clock.start())
-    clock = Clock(dut.clk, 83, units='ns')
-    cocotb.start_soon(clock.start())
+    clock_24m = Clock(dut.clk, 40, units='ns')
+    cocotb.start_soon(clock_24m.start())
+    clock_sample = Clock(dut.sample_clk, 40*128, units='ns')
+    cocotb.start_soon(clock_sample.start())
 
     test_values = [
             23173,
@@ -54,7 +54,10 @@ async def test_cal_00(dut):
             expect = ((value - cal_mem[channel*2]) *
                       cal_mem[channel*2 + 1]) >> 10
             cal_inx.value = Force(signed_to_twos_comp(value))
+            if expect >  32000: expect = 32000
+            if expect < -32000: expect = -32000
             print(f"ch={channel}\t{int(value):6d}\t", end="")
+            await FallingEdge(dut.sample_clk)
             await RisingEdge(dut.sample_clk)
             await RisingEdge(dut.sample_clk)
             await RisingEdge(dut.sample_clk)

--- a/gateware/sim/cal/tb_cal.py
+++ b/gateware/sim/cal/tb_cal.py
@@ -53,10 +53,9 @@ async def test_cal_00(dut):
         for value in test_values:
             expect = ((value - cal_mem[channel*2]) *
                       cal_mem[channel*2 + 1]) >> 10
-            if expect > 28000: expect = 28000
-            if expect < -28000: expect = -28000
             cal_inx.value = Force(signed_to_twos_comp(value))
             print(f"ch={channel}\t{int(value):6d}\t", end="")
+            await RisingEdge(dut.sample_clk)
             await RisingEdge(dut.sample_clk)
             await RisingEdge(dut.sample_clk)
             output = twos_comp_to_signed(cal_outx.value)

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -97,7 +97,6 @@ assign sample_dac3 = force_cal_output;
 
 `endif
 
-/*
 cal cal_instance (
     .clk     (clk_24mhz),
     .sample_clk  (sample_clk),
@@ -130,12 +129,6 @@ assign cal_out1 = cal_in1;
 assign cal_out2 = cal_in2;
 assign cal_out3 = cal_in3;
 `endif
-*/
-
-assign sample_dac0 = ~sample_adc0;
-assign sample_dac1 = ~sample_adc1;
-assign sample_dac2 = ~sample_adc2;
-assign sample_dac3 = ~sample_adc3;
 
 `ifdef CORE_SAMPLER
 sampler sampler_instance (

--- a/gateware/util/uart_baud_tick_gen.v
+++ b/gateware/util/uart_baud_tick_gen.v
@@ -23,8 +23,8 @@
 module baud_tick_gen(
 	input clk, enable,
 	output tick);
-parameter clk_freq = 12000000;
-parameter baud = 115200;
+parameter clk_freq = 24000000;
+parameter baud     =  1000000;
 parameter oversampling = 1;
 
 function integer log2(input integer v); begin log2=0; while(v >> log2) log2 = log2 + 1; end endfunction

--- a/gateware/util/uart_baud_tick_gen.v
+++ b/gateware/util/uart_baud_tick_gen.v
@@ -23,8 +23,8 @@
 module baud_tick_gen(
 	input clk, enable,
 	output tick);
-parameter clk_freq = 24000000;
-parameter baud     =  1000000;
+parameter clk_freq = 12000000;
+parameter baud     =   115200;
 parameter oversampling = 1;
 
 function integer log2(input integer v); begin log2=0; while(v >> log2) log2 = log2 + 1; end endfunction

--- a/gateware/util/uart_tx.v
+++ b/gateware/util/uart_tx.v
@@ -17,15 +17,16 @@
  *
  */
 
-module uart_tx(
+module uart_tx #(
+    parameter clk_freq = 24000000,
+    parameter baud     = 1000000
+)(
 	input clk,
 	input tx_start,
 	input [7:0] tx_data,
 	output tx,
-	output tx_busy);
-
-parameter clk_freq = 12000000;
-parameter baud = 115200;
+	output tx_busy
+);
 
 wire bit_tick;
 baud_tick_gen #(clk_freq, baud) tickgen(.clk(clk), .enable(tx_busy), .tick(bit_tick));

--- a/gateware/util/uart_tx.v
+++ b/gateware/util/uart_tx.v
@@ -19,7 +19,7 @@
 
 module uart_tx #(
     parameter clk_freq = 24000000,
-    parameter baud     = 1000000
+    parameter baud     =  1000000
 )(
 	input clk,
 	input tx_start,

--- a/gateware/util/uart_tx.v
+++ b/gateware/util/uart_tx.v
@@ -18,8 +18,8 @@
  */
 
 module uart_tx #(
-    parameter clk_freq = 24000000,
-    parameter baud     =  1000000
+    parameter clk_freq = 12000000,
+    parameter baud     =   115200
 )(
 	input clk,
 	input tx_start,


### PR DESCRIPTION
Taken from 24MHz branch with clock scaled back to 12MHz as it's causing the UART calibrator module to fail. LUT usage is worse but we'll need to integrate the pipelined cal module when we switch from 96KHz to 192Khz anyway.