### PR TITLE
cores/transpose: add time-domain pitch shifter

### DIFF
--- a/gateware/Makefile
+++ b/gateware/Makefile
@@ -10,6 +10,8 @@ ADD_SRC = ak4619/i2cinit.sv \
 		  cores/vca.sv \
 		  cores/vco.sv \
 		  cores/delay.sv \
+		  cores/util/delayline.sv \
+		  cores/transpose.sv \
 		  cores/filter.sv \
 		  cores/filter/filter_svf_pipelined.sv
 

--- a/gateware/Makefile
+++ b/gateware/Makefile
@@ -10,7 +10,7 @@ ADD_SRC = ak4619/i2cinit.sv \
 		  cores/vca.sv \
 		  cores/vco.sv \
 		  cores/delay.sv \
-		  cores/util/delayline.sv \
+		  cores/delayline.sv \
 		  cores/transpose.sv \
 		  cores/filter.sv \
 		  cores/filter/filter_svf_pipelined.sv

--- a/gateware/cores/delay.sv
+++ b/gateware/cores/delay.sv
@@ -59,6 +59,8 @@ assign sample_out1 = rdata;
 // Raw instantiation of an ICE40 RAM primitive. We could do this using
 // pure Verilog which would be synthesized to this, but it's interesting
 // to have a mental picture of what the hardware looks like.
+//
+// You can easily do this without raw instantiation. See `delayline.sv`.
 SB_RAM40_4K #(
     // MODE 0: 256x16bits == 256 samples delay buffer.
     .WRITE_MODE(0),

--- a/gateware/cores/delayline.sv
+++ b/gateware/cores/delayline.sv
@@ -1,3 +1,7 @@
+// Delay line with real-time adjustable delay from 1 sample up to
+// MAX_DELAY samples. MAX_DELAY must be a power of 2, but the
+// current amount of delay requested does not need to be.
+
 module delayline #(
     parameter W = 16,
     parameter MAX_DELAY = 1024
@@ -5,10 +9,8 @@ module delayline #(
     input sample_clk,
     input [$clog2(MAX_DELAY)-1:0] delay,
     input signed [W-1:0] in,
-    output signed [W-1:0] out
+    output logic signed [W-1:0] out
 );
-
-logic signed [W-1:0] rdata;
 
 logic [$clog2(MAX_DELAY)-1:0] raddr = 1;
 logic [$clog2(MAX_DELAY)-1:0] waddr = 0;
@@ -17,11 +19,11 @@ logic signed [W-1:0] bram[MAX_DELAY];
 
 always_ff @(posedge sample_clk) begin
     waddr <= waddr + 1;
+    // This subtraction wraps correctly as long as MAX_DELAY is
+    // a power of 2.
     raddr <= waddr - delay;
     bram[waddr] <= in;
-    rdata <= bram[raddr];
+    out <= bram[raddr];
 end
-
-assign out = rdata;
 
 endmodule

--- a/gateware/cores/transpose.sv
+++ b/gateware/cores/transpose.sv
@@ -1,0 +1,65 @@
+module transpose #(
+    parameter W = 16,
+    parameter FP_OFFSET = 2,
+    parameter WINDOW = 512,
+    parameter XFADE = 64
+)(
+    input clk,
+    input sample_clk,
+    input signed [W-1:0] sample_in0,
+    input signed [W-1:0] sample_in1,
+    input signed [W-1:0] sample_in2,
+    input signed [W-1:0] sample_in3,
+    output logic signed [W-1:0] sample_out0,
+    output logic signed [W-1:0] sample_out1,
+    output logic signed [W-1:0] sample_out2,
+    output logic signed [W-1:0] sample_out3
+);
+
+logic [15:0] d = 0;
+logic [8:0] delay;
+assign delay = d[9:1];
+always_ff @(posedge sample_clk) begin
+    // This value -1 is actually the 'pitch shift' amount.
+    d <= d - 1;
+end
+
+logic signed [W-1:0] delay_out0;
+logic signed [W-1:0] delay_out1;
+
+delayline delay_0(
+    .sample_clk(sample_clk),
+    .delay(10'(delay)),
+    .in(sample_in0),
+    .out(delay_out0)
+);
+
+delayline delay_1(
+    .sample_clk(sample_clk),
+    .delay(10'(delay)+WINDOW),
+    .in(sample_in0),
+    .out(delay_out1)
+);
+
+logic [7:0] env0;
+logic [7:0] env1;
+logic signed [7:0] env0_reg;
+logic signed [7:0] env1_reg;
+
+always_ff @(posedge sample_clk) begin
+    if (delay < XFADE) begin
+        env0 <= delay[7:0];
+        env1 <= (XFADE-1) - delay[7:0];
+    end else begin
+        env0 <= XFADE-1;
+        env1 <= 0;
+    end
+    env0_reg <= env0;
+    env1_reg <= env1;
+
+    // TODO: shift based on # bits in crossfade
+    sample_out0 <= 16'((32'(delay_out0) * 32'(env0_reg)) >>> 7) +
+                   16'((32'(delay_out1) * 32'(env1_reg)) >>> 7);
+end
+
+endmodule

--- a/gateware/cores/transpose.sv
+++ b/gateware/cores/transpose.sv
@@ -1,3 +1,21 @@
+// Transpose / pitch shift.
+//
+// Given input audio on input 0, pitch shift it.
+//
+// This core saves incoming samples into 2 delay lines, plays them
+// back at modified speed, and cross-fades between them to avoid
+// discontinuities. Basically we chop up the input into grains of
+// size WINDOW and speed them up in the time domain. This allows
+// us to do pitch shifting without time stretching.
+//
+// Loosely inspired by the 'transpose' function from Faust.
+//
+// Mapping:
+// - Input 0: Audio input
+// - Output 0: Audio input (mirrored)
+// - Output 1: Audio input (transposed)
+// - Output 2: Audio input (dry + transposed mixed)
+
 module transpose #(
     parameter W = 16,
     parameter FP_OFFSET = 2,
@@ -16,16 +34,22 @@ module transpose #(
     output logic signed [W-1:0] sample_out3
 );
 
+// Fractional delay and the offset fed into delay lines.
 logic [15:0] d = 0;
 logic [8:0] delay;
-assign delay = d[9:1];
-always_ff @(posedge sample_clk) begin
-    // This value -1 is actually the 'pitch shift' amount.
-    d <= d - 1;
-end
 
+// Output of the delay lines
 logic signed [W-1:0] delay_out0;
 logic signed [W-1:0] delay_out1;
+
+// Cross-fading envelopes
+logic [7:0] env0;
+logic [7:0] env1;
+logic signed [7:0] env0_reg;
+logic signed [7:0] env1_reg;
+
+// Some LSBs of `d` are fractional.
+assign delay = d[9:1];
 
 delayline delay_0(
     .sample_clk(sample_clk),
@@ -41,12 +65,15 @@ delayline delay_1(
     .out(delay_out1)
 );
 
-logic [7:0] env0;
-logic [7:0] env1;
-logic signed [7:0] env0_reg;
-logic signed [7:0] env1_reg;
-
 always_ff @(posedge sample_clk) begin
+    // This value -1 is actually the 'pitch shift' amount. We are
+    // walking up the delay lines (-1 >> 1 == -0.5x) faster than
+    // usual (as we are dropping the lsb of `d`, which means we
+    // pitch UP by 50%, or a perfect 5th.
+    //
+    // TODO: control this from an input.
+    d <= d - 1;
+
     if (delay < XFADE) begin
         env0 <= delay[7:0];
         env1 <= (XFADE-1) - delay[7:0];
@@ -54,12 +81,16 @@ always_ff @(posedge sample_clk) begin
         env0 <= XFADE-1;
         env1 <= 0;
     end
+
+    // Envelopes need to be delayed by 1 sample to avoid discontinuity.
     env0_reg <= env0;
     env1_reg <= env1;
 
-    // TODO: shift based on # bits in crossfade
-    sample_out0 <= 16'((32'(delay_out0) * 32'(env0_reg)) >>> 7) +
-                   16'((32'(delay_out1) * 32'(env1_reg)) >>> 7);
+    sample_out1 <= 16'((32'(delay_out0) * 32'(env0_reg)) >>> ($clog2(XFADE))) +
+                   16'((32'(delay_out1) * 32'(env1_reg)) >>> ($clog2(XFADE)));
 end
+
+assign sample_out0 = sample_in0;
+assign sample_out2 = (sample_in0 >>> 1) + (sample_out1 >>> 1);
 
 endmodule

--- a/gateware/cores/util/delayline.sv
+++ b/gateware/cores/util/delayline.sv
@@ -1,0 +1,27 @@
+module delayline #(
+    parameter W = 16,
+    parameter MAX_DELAY = 1024
+)(
+    input sample_clk,
+    input [$clog2(MAX_DELAY)-1:0] delay,
+    input signed [W-1:0] in,
+    output signed [W-1:0] out
+);
+
+logic signed [W-1:0] rdata;
+
+logic [$clog2(MAX_DELAY)-1:0] raddr = 1;
+logic [$clog2(MAX_DELAY)-1:0] waddr = 0;
+
+logic signed [W-1:0] bram[MAX_DELAY];
+
+always_ff @(posedge sample_clk) begin
+    waddr <= waddr + 1;
+    raddr <= waddr - delay;
+    bram[waddr] <= in;
+    rdata <= bram[raddr];
+end
+
+assign out = rdata;
+
+endmodule

--- a/gateware/scripts/verilator_lint.sh
+++ b/gateware/scripts/verilator_lint.sh
@@ -8,3 +8,4 @@ verilator --lint-only -Icores seqswitch.sv
 verilator --lint-only -Icores vca.sv
 verilator --lint-only -Icores vco.sv
 verilator --lint-only -Icores -Iutil delay.sv
+verilator --lint-only -Icores transpose.sv

--- a/gateware/sim/transpose/Makefile
+++ b/gateware/sim/transpose/Makefile
@@ -1,6 +1,6 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
-VERILOG_SOURCES = ../../cores/transpose.sv ../../cores/util/delayline.sv
+VERILOG_SOURCES = ../../cores/transpose.sv ../../cores/delayline.sv
 MODULE = tb_transpose
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/gateware/sim/transpose/Makefile
+++ b/gateware/sim/transpose/Makefile
@@ -1,0 +1,6 @@
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+VERILOG_SOURCES = ../../cores/transpose.sv ../../cores/util/delayline.sv
+MODULE = tb_transpose
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/gateware/sim/transpose/tb_transpose.py
+++ b/gateware/sim/transpose/tb_transpose.py
@@ -1,0 +1,77 @@
+import pickle
+import cocotb
+import random
+import math
+from cocotb.clock import Clock
+from cocotb.triggers import Timer, FallingEdge, RisingEdge, ClockCycles
+from cocotb.handle import Force, Release
+
+def bit_not(n, numbits=16):
+    return (1 << numbits) - 1 - n
+
+def signed_to_twos_comp(n, numbits=16):
+    return n if n >= 0 else bit_not(-n, numbits) + 1
+
+def twos_comp_to_signed(n, numbits=16):
+    if (1 << (numbits-1) & n) > 0:
+        return -int(bit_not(n, numbits) + 1)
+    else:
+        return int(n)
+
+@cocotb.test()
+async def test_transpose_00(dut):
+
+    clock = Clock(dut.sample_clk, 5, units='us')
+    cocotb.start_soon(clock.start())
+    clock = Clock(dut.clk, 83, units='ns')
+    cocotb.start_soon(clock.start())
+
+    dut.sample_in0.value = 0
+
+    for i in range(1024):
+        await RisingEdge(dut.sample_clk)
+
+    ins = []
+    out0 = []
+    out1 = []
+    outs = []
+
+    data_out_last = None
+
+    breaknext = False
+
+    for i in range(4096):
+        await RisingEdge(dut.sample_clk)
+
+        data_in = int(1000*math.sin(i / 100))
+        dut.sample_in0.value = signed_to_twos_comp(data_in)
+
+        #out0.append(twos_comp_to_signed(dut.sample_out0.value))
+        #out1.append(twos_comp_to_signed(dut.sample_out1.value))
+        data_out = twos_comp_to_signed(dut.sample_out0.value)
+
+        print(f"i={i} in:", data_in)
+        print(f"i={i} out:", data_out)
+        #print(f"i={i} delay0:", out0[-1])
+        #print(f"i={i} delay1:", out1[-1])
+
+        ins.append(data_in)
+        outs.append(data_out)
+
+        if data_out_last is not None:
+            print(f"del0: {int(dut.delay_out0)}")
+            print(f"env0: {int(dut.env0)}")
+            print(f"del1: {int(dut.delay_out1)}")
+            print(f"env1: {int(dut.env1)}")
+            if breaknext:
+                break
+            if abs(data_out - data_out_last) > 50:
+                print("=========================")
+                breaknext = True
+
+        data_out_last = data_out
+
+    """
+    with open("dump.pkl", "wb") as f:
+        pickle.dump({"i": ins, "o0": out0, "o1": out1, "o2": out2})
+        """

--- a/gateware/sim/transpose/tb_transpose.py
+++ b/gateware/sim/transpose/tb_transpose.py
@@ -27,6 +27,7 @@ async def test_transpose_00(dut):
     cocotb.start_soon(clock.start())
 
     dut.sample_in0.value = 0
+    dut.sample_in1.value = 5000*4
 
     # Clock in some zeroes so the delay lines are full of zeroes.
 

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -19,13 +19,13 @@
 //`define CORE_CLKDIV
 //`define CORE_SEQSWITCH
 //`define CORE_SAMPLER
-//`define CORE_MIRROR
+`define CORE_MIRROR
 //`define CORE_VCA
 //`define CORE_VCO
 //`define CORE_FILTER
 //`define CORE_BITCRUSH
 //`define CORE_DELAY
-`define CORE_TRANSPOSE
+//`define CORE_TRANSPOSE
 
 module top #(
     parameter int W = 16 // sample width, bits

--- a/gateware/top.sv
+++ b/gateware/top.sv
@@ -19,12 +19,13 @@
 //`define CORE_CLKDIV
 //`define CORE_SEQSWITCH
 //`define CORE_SAMPLER
-`define CORE_MIRROR
+//`define CORE_MIRROR
 //`define CORE_VCA
 //`define CORE_VCO
 //`define CORE_FILTER
 //`define CORE_BITCRUSH
 //`define CORE_DELAY
+`define CORE_TRANSPOSE
 
 module top #(
     parameter int W = 16 // sample width, bits
@@ -232,6 +233,21 @@ vco vco_instance (
 
 `ifdef CORE_DELAY
 delay delay_instance (
+    .clk     (clk_12mhz),
+    .sample_clk  (sample_clk),
+    .sample_in0 (cal_in0),
+    .sample_in1 (cal_in1),
+    .sample_in2 (cal_in2),
+    .sample_in3 (cal_in3),
+    .sample_out0 (cal_out0),
+    .sample_out1 (cal_out1),
+    .sample_out2 (cal_out2),
+    .sample_out3 (cal_out3)
+);
+`endif
+
+`ifdef CORE_TRANSPOSE
+transpose transpose_instance (
     .clk     (clk_12mhz),
     .sample_clk  (sample_clk),
     .sample_in0 (cal_in0),


### PR DESCRIPTION
Add an example core which pitch shifts the input audio by an amount dictated by CV control